### PR TITLE
#62: Migration done

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,8 @@ dist: trusty
 jdk:
 - openjdk8
 - oraclejdk9
+script:
+- java -version
+- mvn clean install -Pextras --errors
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/deploy.sh
+++ b/deploy.sh
@@ -13,5 +13,4 @@ mv /tmp/README.md ./README.md
 mvn clean deploy -Pextras,ossrh
 git commit -am "[release] puzzlerbot-${TAG}"
 git tag -f ${TAG}
-git push origin ${TAG}
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,13 +28,6 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
-    <parent>
-        <groupId>oo</groupId>
-        <artifactId>atom-starter</artifactId>
-        <version>0.0.12</version>
-    </parent>
-
     <groupId>com.github.skapral.puzzler</groupId>
     <artifactId>puzzler</artifactId>
     <packaging>pom</packaging>
@@ -93,6 +86,50 @@
         </repository>
     </repositories>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.pragmaticobjects.oo.tests</groupId>
+                <artifactId>tests-junit5</artifactId>
+                <version>0.0.0</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.pragmaticobjects.oo.atom</groupId>
+                <artifactId>atom-maven-plugin</artifactId>
+                <version>0.0.13</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate-annotations</goal>
+                            <goal>instrument</goal>
+                            <goal>instrument-tests</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.21.0</version>
+                <configuration>
+                    <trimStackTrace>false</trimStackTrace>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-surefire-provider</artifactId>
+                        <version>1.2.0</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+
     <profiles>
         <profile>
             <id>coverage</id>
@@ -145,6 +182,9 @@
                         <executions>
                             <execution>
                                 <configuration>
+                                    <sourceDirectories>
+                                        <sourceDirectory>src/main/java</sourceDirectory>
+                                    </sourceDirectories>
                                     <logViolationsToConsole>true</logViolationsToConsole>
                                     <configLocation>checkstyle.xml</configLocation>
                                     <encoding>UTF-8</encoding>

--- a/puzzler-app/src/main/java/com/github/skapral/puzzler/app/Bootstrap.java
+++ b/puzzler-app/src/main/java/com/github/skapral/puzzler/app/Bootstrap.java
@@ -28,7 +28,7 @@ package com.github.skapral.puzzler.app;
 import com.github.skapral.puzzler.config.Cp_PORT;
 import com.github.skapral.puzzler.web.SrvGrizzlyWithJersey;
 import com.github.skapral.puzzler.web.jersey.PuzzlerAPI;
-import oo.atom.anno.NotAtom;
+import com.pragmaticobjects.oo.atom.anno.NotAtom;
 
 /**
  * Starting point.

--- a/puzzler-core/pom.xml
+++ b/puzzler-core/pom.xml
@@ -42,6 +42,11 @@
             <version>0.9.0</version>
         </dependency>
         <dependency>
+            <groupId>com.pragmaticobjects.oo.tests</groupId>
+            <artifactId>tests-junit5</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>3.8.0</version>

--- a/puzzler-core/src/main/java/com/github/skapral/puzzler/core/operation/AssertOperationFails.java
+++ b/puzzler-core/src/main/java/com/github/skapral/puzzler/core/operation/AssertOperationFails.java
@@ -26,7 +26,7 @@
 package com.github.skapral.puzzler.core.operation;
 
 import com.github.skapral.puzzler.core.Operation;
-import oo.atom.tests.Assertion;
+import com.pragmaticobjects.oo.tests.Assertion;
 import org.assertj.core.api.Assertions;
 
 /**

--- a/puzzler-core/src/main/java/com/github/skapral/puzzler/core/operation/AssertOperationSuccessful.java
+++ b/puzzler-core/src/main/java/com/github/skapral/puzzler/core/operation/AssertOperationSuccessful.java
@@ -26,7 +26,7 @@
 package com.github.skapral.puzzler.core.operation;
 
 import com.github.skapral.puzzler.core.Operation;
-import oo.atom.tests.Assertion;
+import com.pragmaticobjects.oo.tests.Assertion;
 import org.assertj.core.api.Assertions;
 
 /**

--- a/puzzler-core/src/main/java/com/github/skapral/puzzler/core/puzzle/AssertPuzzleHasCertainTitleAndDescription.java
+++ b/puzzler-core/src/main/java/com/github/skapral/puzzler/core/puzzle/AssertPuzzleHasCertainTitleAndDescription.java
@@ -26,7 +26,7 @@
 package com.github.skapral.puzzler.core.puzzle;
 
 import com.github.skapral.puzzler.core.Puzzle;
-import oo.atom.tests.Assertion;
+import com.pragmaticobjects.oo.tests.Assertion;
 import org.assertj.core.api.Assertions;
 
 /**

--- a/puzzler-core/src/main/java/com/github/skapral/puzzler/core/source/AssertPuzzleSourceProducesCertainPuzzles.java
+++ b/puzzler-core/src/main/java/com/github/skapral/puzzler/core/source/AssertPuzzleSourceProducesCertainPuzzles.java
@@ -28,7 +28,7 @@ package com.github.skapral.puzzler.core.source;
 import com.github.skapral.puzzler.core.Puzzle;
 import com.github.skapral.puzzler.core.PuzzleSource;
 import io.vavr.collection.List;
-import oo.atom.tests.Assertion;
+import com.pragmaticobjects.oo.tests.Assertion;
 import org.assertj.core.api.Assertions;
 
 import java.util.function.Function;

--- a/puzzler-core/src/main/java/com/github/skapral/puzzler/core/text/threepars/AssertTextInstanceProducesCertainParagraphs.java
+++ b/puzzler-core/src/main/java/com/github/skapral/puzzler/core/text/threepars/AssertTextInstanceProducesCertainParagraphs.java
@@ -26,7 +26,7 @@
 package com.github.skapral.puzzler.core.text.threepars;
 
 import io.vavr.collection.List;
-import oo.atom.tests.Assertion;
+import com.pragmaticobjects.oo.tests.Assertion;
 import org.assertj.core.api.Assertions;
 
 import java.util.function.Function;

--- a/puzzler-core/src/test/java/com/github/skapral/puzzler/core/puzzle/AssertPuzzleHasCertainTitleAndDescriptionTest.java
+++ b/puzzler-core/src/test/java/com/github/skapral/puzzler/core/puzzle/AssertPuzzleHasCertainTitleAndDescriptionTest.java
@@ -26,10 +26,10 @@
 package com.github.skapral.puzzler.core.puzzle;
 
 
-import oo.atom.tests.AssertAssertionFails;
-import oo.atom.tests.AssertAssertionPasses;
-import oo.atom.tests.TestCase;
-import oo.atom.tests.TestsSuite;
+import com.pragmaticobjects.oo.tests.AssertAssertionFails;
+import com.pragmaticobjects.oo.tests.AssertAssertionPasses;
+import com.pragmaticobjects.oo.tests.TestCase;
+import com.pragmaticobjects.oo.tests.junit5.TestsSuite;
 
 class AssertPuzzleHasCertainTitleAndDescriptionTest extends TestsSuite {
     public AssertPuzzleHasCertainTitleAndDescriptionTest() {

--- a/puzzler-core/src/test/java/com/github/skapral/puzzler/core/source/AssertPuzzleSourceProducesCertainPuzzlesTest.java
+++ b/puzzler-core/src/test/java/com/github/skapral/puzzler/core/source/AssertPuzzleSourceProducesCertainPuzzlesTest.java
@@ -26,10 +26,10 @@
 package com.github.skapral.puzzler.core.source;
 
 import com.github.skapral.puzzler.core.puzzle.PzlStatic;
-import oo.atom.tests.AssertAssertionFails;
-import oo.atom.tests.AssertAssertionPasses;
-import oo.atom.tests.TestCase;
-import oo.atom.tests.TestsSuite;
+import com.pragmaticobjects.oo.tests.AssertAssertionFails;
+import com.pragmaticobjects.oo.tests.AssertAssertionPasses;
+import com.pragmaticobjects.oo.tests.TestCase;
+import com.pragmaticobjects.oo.tests.junit5.TestsSuite;
 
 class AssertPuzzleSourceProducesCertainPuzzlesTest extends TestsSuite {
     public AssertPuzzleSourceProducesCertainPuzzlesTest() {

--- a/puzzler-core/src/test/java/com/github/skapral/puzzler/core/text/threepars/AssertTextInstanceProducesCertainParagraphsTest.java
+++ b/puzzler-core/src/test/java/com/github/skapral/puzzler/core/text/threepars/AssertTextInstanceProducesCertainParagraphsTest.java
@@ -25,10 +25,10 @@
 
 package com.github.skapral.puzzler.core.text.threepars;
 
-import oo.atom.tests.AssertAssertionFails;
-import oo.atom.tests.AssertAssertionPasses;
-import oo.atom.tests.TestCase;
-import oo.atom.tests.TestsSuite;
+import com.pragmaticobjects.oo.tests.AssertAssertionFails;
+import com.pragmaticobjects.oo.tests.AssertAssertionPasses;
+import com.pragmaticobjects.oo.tests.TestCase;
+import com.pragmaticobjects.oo.tests.junit5.TestsSuite;
 
 class AssertTextInstanceProducesCertainParagraphsTest extends TestsSuite {
     public AssertTextInstanceProducesCertainParagraphsTest() {

--- a/puzzler-core/src/test/java/com/github/skapral/puzzler/core/text/threepars/TxtStandardTest.java
+++ b/puzzler-core/src/test/java/com/github/skapral/puzzler/core/text/threepars/TxtStandardTest.java
@@ -25,8 +25,8 @@
 
 package com.github.skapral.puzzler.core.text.threepars;
 
-import oo.atom.tests.TestCase;
-import oo.atom.tests.TestsSuite;
+import com.pragmaticobjects.oo.tests.TestCase;
+import com.pragmaticobjects.oo.tests.junit5.TestsSuite;
 
 class TxtStandardTest extends TestsSuite {
     public TxtStandardTest() {

--- a/puzzler-web/pom.xml
+++ b/puzzler-web/pom.xml
@@ -88,6 +88,11 @@
             <version>1.11</version>
         </dependency>
         <dependency>
+            <groupId>com.pragmaticobjects.oo.tests</groupId>
+            <artifactId>tests-junit5</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-netty</artifactId>
             <version>5.3.0</version>

--- a/puzzler-web/src/main/java/com/github/skapral/puzzler/github/mock/AssertAssumingMockServer.java
+++ b/puzzler-web/src/main/java/com/github/skapral/puzzler/github/mock/AssertAssumingMockServer.java
@@ -25,7 +25,7 @@
 
 package com.github.skapral.puzzler.github.mock;
 
-import oo.atom.tests.Assertion;
+import com.pragmaticobjects.oo.tests.Assertion;
 
 /**
  * Assertion on up-and-running Github mock server

--- a/puzzler-web/src/main/java/com/github/skapral/puzzler/github/mock/GmsImplementation.java
+++ b/puzzler-web/src/main/java/com/github/skapral/puzzler/github/mock/GmsImplementation.java
@@ -25,7 +25,7 @@
 
 package com.github.skapral.puzzler.github.mock;
 
-import oo.atom.anno.NotAtom;
+import com.pragmaticobjects.oo.atom.anno.NotAtom;
 import org.mockserver.client.server.MockServerClient;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.HttpRequest;

--- a/puzzler-web/src/main/java/com/github/skapral/puzzler/web/jersey/AuthenticationExceptionMapper.java
+++ b/puzzler-web/src/main/java/com/github/skapral/puzzler/web/jersey/AuthenticationExceptionMapper.java
@@ -25,7 +25,7 @@
 
 package com.github.skapral.puzzler.web.jersey;
 
-import oo.atom.anno.NotAtom;
+import com.pragmaticobjects.oo.atom.anno.NotAtom;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;

--- a/puzzler-web/src/main/java/com/github/skapral/puzzler/web/jersey/DefaultExceptionMapper.java
+++ b/puzzler-web/src/main/java/com/github/skapral/puzzler/web/jersey/DefaultExceptionMapper.java
@@ -25,7 +25,7 @@
 
 package com.github.skapral.puzzler.web.jersey;
 
-import oo.atom.anno.NotAtom;
+import com.pragmaticobjects.oo.atom.anno.NotAtom;
 
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;

--- a/puzzler-web/src/main/java/com/github/skapral/puzzler/web/jersey/GithubHookEndpoint.java
+++ b/puzzler-web/src/main/java/com/github/skapral/puzzler/web/jersey/GithubHookEndpoint.java
@@ -34,7 +34,7 @@ import com.github.skapral.puzzler.github.operation.OpIgnoringUnprivildgedEventSe
 import com.github.skapral.puzzler.github.operation.OpValidatingEventSignature;
 import com.github.skapral.puzzler.github.project.GprjFromGithubEvent;
 import com.github.skapral.puzzler.github.source.PsrcFromGithubEvent;
-import oo.atom.anno.NotAtom;
+import com.pragmaticobjects.oo.atom.anno.NotAtom;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.Response;

--- a/puzzler-web/src/main/java/com/github/skapral/puzzler/web/jersey/PuzzlerAPI.java
+++ b/puzzler-web/src/main/java/com/github/skapral/puzzler/web/jersey/PuzzlerAPI.java
@@ -25,7 +25,7 @@
 
 package com.github.skapral.puzzler.web.jersey;
 
-import oo.atom.anno.NotAtom;
+import com.pragmaticobjects.oo.atom.anno.NotAtom;
 import org.glassfish.jersey.server.ResourceConfig;
 
 /**

--- a/puzzler-web/src/main/java/com/github/skapral/puzzler/web/jersey/StatusEndpoint.java
+++ b/puzzler-web/src/main/java/com/github/skapral/puzzler/web/jersey/StatusEndpoint.java
@@ -25,7 +25,7 @@
 
 package com.github.skapral.puzzler.web.jersey;
 
-import oo.atom.anno.NotAtom;
+import com.pragmaticobjects.oo.atom.anno.NotAtom;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;

--- a/puzzler-web/src/test/java/com/github/skapral/puzzler/github/operation/OpIgnoringUnprivildgedEventSenderTest.java
+++ b/puzzler-web/src/test/java/com/github/skapral/puzzler/github/operation/OpIgnoringUnprivildgedEventSenderTest.java
@@ -3,8 +3,8 @@ package com.github.skapral.puzzler.github.operation;
 import com.github.skapral.puzzler.core.operation.AssertOperationFails;
 import com.github.skapral.puzzler.core.operation.AssertOperationSuccessful;
 import com.github.skapral.puzzler.core.operation.OpFail;
-import oo.atom.tests.TestCase;
-import oo.atom.tests.TestsSuite;
+import com.pragmaticobjects.oo.tests.TestCase;
+import com.pragmaticobjects.oo.tests.junit5.TestsSuite;
 import org.apache.commons.io.IOUtils;
 
 class OpIgnoringUnprivildgedEventSenderTest extends TestsSuite {

--- a/puzzler-web/src/test/java/com/github/skapral/puzzler/github/operation/OpValidatingEventSignatureTest.java
+++ b/puzzler-web/src/test/java/com/github/skapral/puzzler/github/operation/OpValidatingEventSignatureTest.java
@@ -30,8 +30,8 @@ import com.github.skapral.puzzler.config.CpStatic;
 import com.github.skapral.puzzler.core.operation.AssertOperationFails;
 import com.github.skapral.puzzler.core.operation.AssertOperationSuccessful;
 import com.github.skapral.puzzler.core.operation.OpDoNothing;
-import oo.atom.tests.TestCase;
-import oo.atom.tests.TestsSuite;
+import com.pragmaticobjects.oo.tests.TestCase;
+import com.pragmaticobjects.oo.tests.junit5.TestsSuite;
 import org.apache.commons.io.IOUtils;
 
 class OpValidatingEventSignatureTest extends TestsSuite {

--- a/puzzler-web/src/test/java/com/github/skapral/puzzler/github/source/PsrcFromGithubCommentsTest.java
+++ b/puzzler-web/src/test/java/com/github/skapral/puzzler/github/source/PsrcFromGithubCommentsTest.java
@@ -27,8 +27,8 @@ package com.github.skapral.puzzler.github.source;
 
 import com.github.skapral.puzzler.core.puzzle.PzlStatic;
 import com.github.skapral.puzzler.core.source.AssertPuzzleSourceProducesCertainPuzzles;
-import oo.atom.tests.TestCase;
-import oo.atom.tests.TestsSuite;
+import com.pragmaticobjects.oo.tests.TestCase;
+import com.pragmaticobjects.oo.tests.junit5.TestsSuite;
 import org.apache.commons.io.IOUtils;
 
 import java.nio.charset.Charset;

--- a/puzzler-web/src/test/java/com/github/skapral/puzzler/github/source/PsrcFromGithubEventTest.java
+++ b/puzzler-web/src/test/java/com/github/skapral/puzzler/github/source/PsrcFromGithubEventTest.java
@@ -31,8 +31,8 @@ import com.github.skapral.puzzler.core.source.AssertPuzzleSourceProducesCertainP
 import com.github.skapral.puzzler.core.source.AssertPuzzleSourceProducesNoPuzzles;
 import com.github.skapral.puzzler.github.mock.AssertAssumingMockServer;
 import com.github.skapral.puzzler.github.mock.GmsImplementation;
-import oo.atom.tests.TestCase;
-import oo.atom.tests.TestsSuite;
+import com.pragmaticobjects.oo.tests.TestCase;
+import com.pragmaticobjects.oo.tests.junit5.TestsSuite;
 import org.apache.commons.io.IOUtils;
 
 import java.nio.charset.Charset;


### PR DESCRIPTION
Closes #62 

## Root cause of the issue
Upgrade of oo-atom was required, since:
- version 0.0.13 heavily impacts oo-atom-based projects.
- version 0.0.13 fixes some windows-specific issues (needed for #14).

## Description of the changes
- Removed oo-atom starter of older version
- Added atom-maven-plugin 0.0.13
- Added oo-tests for reusable assertions support

Also made some slight changes to improve CI and deployment.

## Checklist

- [x] No classes in this PR were explicitly annotated with `@Atom` or `@NotAtom` annotation,
or the reason for such intention is provided in PR description.
