### PR TITLE
#14: AppVeyor integrated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Puzzler bot
 
-[![Build Status](https://img.shields.io/travis/skapral/puzzlerbot/master.svg)](https://travis-ci.org/skapral/puzzlerbot)
+[![Build Status (Travis)](https://img.shields.io/travis/skapral/puzzlerbot/master.svg)](https://travis-ci.org/skapral/puzzlerbot)
+[![Build status (AppVeyor)](https://ci.appveyor.com/api/projects/status/1mwgh02plynasibk/branch/master?svg=true)](https://ci.appveyor.com/project/skapral/puzzlerbot/branch/master)
+
 [![Codecov](https://codecov.io/gh/skapral/puzzlerbot/branch/master/graph/badge.svg)](https://codecov.io/gh/skapral/puzzlerbot)
 
 @todo #31 to add some badge which will show the `@puzzlerbot`'s status.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,22 @@
+branches:
+  only:
+    - master
+install:
+  - ps: |
+      Add-Type -AssemblyName System.IO.Compression.FileSystem
+      if (!(Test-Path -Path "C:\maven" )) {
+        (new-object System.Net.WebClient).DownloadFile('http://www.us.apache.org/dist/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.zip', 'C:\maven-bin.zip')
+        [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")
+      }
+  - cmd: SET M2_HOME=C:\maven\apache-maven-3.3.9
+  - cmd: SET PATH=%M2_HOME%\bin;%JAVA_HOME%\bin;%PATH:C:\Ruby193\bin;=%
+  - cmd: SET JAVA_OPTS=-XX:MaxPermSize=2g -Xmx4g
+  - cmd: mvn --version
+  - cmd: java -version
+build_script:
+  - mvn clean package -B -Dmaven.test.skip=true
+test_script:
+  - mvn clean install -Pextras --errors --batch-mode
+cache:
+  - C:\maven\
+  - C:\Users\appveyor\.m2


### PR DESCRIPTION
Closes #14

## Root cause of the issue
AppVeyor integration was missing

## Description of the changes
Integrated puzzlerbot repository with AppVeyor, placing a badge in README.md

## Checklist

- [X] No classes in this PR were explicitly annotated with `@Atom` or `@NotAtom` annotation,
or the reason for such intention is provided in PR description.
