### PR TITLE
#15: Refactored TxtStandard

### DIFF
--- a/puzzler-core/src/main/java/com/github/skapral/puzzler/core/package-info.java
+++ b/puzzler-core/src/main/java/com/github/skapral/puzzler/core/package-info.java
@@ -32,7 +32,7 @@
  *         it is used to identify that the text is the puzzle and provide the metadata.
  *     </li>
  *     <li>
- *         First non-controlling paragraph in the text is the puzzle's title.
+ *         First non-controlling non-empty paragraph in the text is the puzzle's title.
  *     </li>
  *     <li>
  *         The rest non-controlling paragraphs are combined into description.

--- a/puzzler-core/src/main/java/com/github/skapral/puzzler/core/text/threepars/TxtBase.java
+++ b/puzzler-core/src/main/java/com/github/skapral/puzzler/core/text/threepars/TxtBase.java
@@ -1,0 +1,63 @@
+package com.github.skapral.puzzler.core.text.threepars;
+
+import io.vavr.collection.List;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+
+/**
+ * Basic three-paragraphs text implementation
+ *
+ * @author Kapralov Sergey
+ */
+public class TxtBase implements Text {
+    private final TriggerWord triggerWord;
+    private final String text;
+
+    /**
+     * Ctor.
+     *
+     * @param triggerWord Trigger word.
+     * @param text Text to parse.
+     */
+    public TxtBase(TriggerWord triggerWord, String text) {
+        this.triggerWord = triggerWord;
+        this.text = text;
+    }
+
+    @Override
+    public final List<Paragraph> paragraphs() {
+        try(BufferedReader reader = new BufferedReader(new StringReader(text))) {
+            boolean titleFound = false;
+            final ArrayList<Paragraph> result = new ArrayList<>();
+            for(String line : reader.lines().collect(Collectors.toList())) {
+                if(line.contains(triggerWord.value())) {
+                    result.add(
+                        new ParStatic(Paragraph.Type.CONTROLLING, line)
+                    );
+                } else if(!line.trim().isEmpty() && !titleFound) {
+                    titleFound = true;
+                    result.add(
+                        new ParStatic(
+                            Paragraph.Type.TITLE,
+                            line
+                        )
+                    );
+                } else {
+                    result.add(
+                        new ParStatic(
+                            Paragraph.Type.DESCRIPTION,
+                            line
+                        )
+                    );
+                }
+            }
+            return List.ofAll(result);
+        } catch(IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/puzzler-core/src/main/java/com/github/skapral/puzzler/core/text/threepars/TxtStandard.java
+++ b/puzzler-core/src/main/java/com/github/skapral/puzzler/core/text/threepars/TxtStandard.java
@@ -25,27 +25,12 @@
 
 package com.github.skapral.puzzler.core.text.threepars;
 
-import io.vavr.collection.List;
-
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.StringReader;
-import java.util.ArrayList;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
 /**
- * Text standard implementation. Splits the string by three-paragraph approach,
- * omitting leading and trailing empty paragraphs.
+ * Standard three-paragraphs text implementation, which produces
  *
  * @author Kapralov Sergey
- * @todo #7 Split this object to two: one for splitting text to paragraphs,
- *  another for trimming empty paragraphs in the beginning and end.
  */
-public class TxtStandard implements Text {
-    private final TriggerWord triggerWord;
-    private final String text;
-
+public class TxtStandard extends TxtTrim {
     /**
      * Ctor.
      *
@@ -53,63 +38,11 @@ public class TxtStandard implements Text {
      * @param text Text to parse.
      */
     public TxtStandard(TriggerWord triggerWord, String text) {
-        this.triggerWord = triggerWord;
-        this.text = text;
-    }
-
-    @Override
-    public final List<Paragraph> paragraphs() {
-        try(BufferedReader reader = new BufferedReader(new StringReader(text))) {
-            boolean titleFound = false;
-            boolean firstNonEmptyParagraphFound = false;
-            int emptyParagraphsCounter = 0;
-            ArrayList<Paragraph> result = new ArrayList<>();
-            for(String line : reader.lines().collect(Collectors.toList())) {
-                if(line.trim().isEmpty()) {
-                    emptyParagraphsCounter++;
-                } else if(line.contains(triggerWord.value())) {
-                    result.add(
-                        new ParStatic(Paragraph.Type.CONTROLLING, line)
-                    );
-                } else if(!titleFound) {
-                    titleFound = true;
-                    emptyParagraphsCounter = 0;
-                    result.add(
-                        new ParStatic(Paragraph.Type.TITLE, line)
-                    );
-                } else if(!firstNonEmptyParagraphFound) {
-                    firstNonEmptyParagraphFound = true;
-                    emptyParagraphsCounter = 0;
-                    result.add(
-                        new ParStatic(
-                            Paragraph.Type.DESCRIPTION,
-                            line
-                        )
-                    );
-                } else {
-                    IntStream.range(
-                        0,
-                        emptyParagraphsCounter
-                    ).forEach(
-                        i -> result.add(
-                            new ParStatic(
-                                Paragraph.Type.DESCRIPTION,
-                                ""
-                            )
-                        )
-                    );
-                    result.add(
-                        new ParStatic(
-                            Paragraph.Type.DESCRIPTION,
-                            line
-                        )
-                    );
-                    emptyParagraphsCounter = 0;
-                }
-            }
-            return List.ofAll(result);
-        } catch(IOException ex) {
-            throw new RuntimeException(ex);
-        }
+        super(
+            new TxtBase(
+                triggerWord,
+                text
+            )
+        );
     }
 }

--- a/puzzler-core/src/main/java/com/github/skapral/puzzler/core/text/threepars/TxtTrim.java
+++ b/puzzler-core/src/main/java/com/github/skapral/puzzler/core/text/threepars/TxtTrim.java
@@ -1,0 +1,69 @@
+package com.github.skapral.puzzler.core.text.threepars;
+
+import io.vavr.collection.List;
+
+import java.util.ArrayList;
+import java.util.function.Predicate;
+import java.util.stream.IntStream;
+
+import static com.github.skapral.puzzler.core.text.threepars.Paragraph.Type.CONTROLLING;
+import static com.github.skapral.puzzler.core.text.threepars.Paragraph.Type.DESCRIPTION;
+import static com.github.skapral.puzzler.core.text.threepars.Paragraph.Type.TITLE;
+
+
+/**
+ * Text, omitting empty leading and trailing paragraphs.
+ *
+ * @author Kapralov Sergey
+ */
+public class TxtTrim implements Text {
+    private final Text text;
+
+    /**
+     * Ctor.
+     *
+     * @param text Text to trim
+     */
+    public TxtTrim(Text text) {
+        this.text = text;
+    }
+
+    @Override
+    public final List<Paragraph> paragraphs() {
+        boolean firstNonEmptyParagraphFound = false;
+        int emptyParagraphsCounter = 0;
+        final ArrayList<Paragraph> result = new ArrayList<>();
+        final Predicate<Paragraph> emptyDescriptionParagraph = p ->
+            p.type().equals(DESCRIPTION) &&
+            p.content().trim().isEmpty();
+        for(Paragraph paragraph : text.paragraphs()) {
+            if(emptyDescriptionParagraph.test(paragraph)) {
+                emptyParagraphsCounter++;
+            } else if(paragraph.type().equals(CONTROLLING)) {
+                result.add(paragraph);
+            } else if(paragraph.type().equals(TITLE)) {
+                emptyParagraphsCounter = 0;
+                result.add(paragraph);
+            } else if(!firstNonEmptyParagraphFound && !paragraph.content().isEmpty()) {
+                firstNonEmptyParagraphFound = true;
+                emptyParagraphsCounter = 0;
+                result.add(paragraph);
+            } else {
+                IntStream.range(
+                    0,
+                    emptyParagraphsCounter
+                ).forEach(
+                    i -> result.add(
+                        new ParStatic(
+                            Paragraph.Type.DESCRIPTION,
+                            ""
+                        )
+                    )
+                );
+                result.add(paragraph);
+                emptyParagraphsCounter = 0;
+            }
+        }
+        return List.ofAll(result);
+    }
+}


### PR DESCRIPTION
## Root cause of the issue
`TxtStandard` is too complex.

## Description of the changes
Refactored `TxtStandard` by splitting it to two single-responcible parts: `TxtBase`, which makes just the paragraphs classification, and `TxtTrim`, which trims empty paragraphs from the beginning and end of the text.

## Checklist

- [X] No classes in this PR were explicitly annotated with `@Atom` or `@NotAtom` annotation,
or the reason for such intention is provided in PR description.
