### PR TITLE
#68: Refactored `PsrcFromGtihubComments`, introduced `PsrcFromComments`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ jdk:
 - oraclejdk9
 script:
 - java -version
-- mvn clean install -Pextras --errors
+- mvn clean install -Pextras,coverage,checkstyle --errors
 after_success:
 - bash <(curl -s https://codecov.io/bash)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ install:
 build_script:
   - mvn clean package -B -Dmaven.test.skip=true
 test_script:
-  - mvn clean install -Pextras --errors --batch-mode
+  - mvn clean install -Pextras,coverage,checkstyle --errors --batch-mode
 cache:
   - C:\maven\
   - C:\Users\appveyor\.m2

--- a/puzzler-core/src/main/java/com/github/skapral/puzzler/core/source/PsrcFromComments.java
+++ b/puzzler-core/src/main/java/com/github/skapral/puzzler/core/source/PsrcFromComments.java
@@ -1,0 +1,56 @@
+package com.github.skapral.puzzler.core.source;
+
+import com.github.skapral.puzzler.core.Puzzle;
+import com.github.skapral.puzzler.core.PuzzleSource;
+import com.github.skapral.puzzler.core.puzzle.PzlUsingThreeParsText;
+import com.github.skapral.puzzler.core.text.threepars.TriggerWord;
+import com.github.skapral.puzzler.core.text.threepars.TxtStandard;
+import io.vavr.collection.List;
+
+import static com.github.skapral.puzzler.core.text.threepars.Paragraph.Type.CONTROLLING;
+
+/**
+ * Puzzle source from a set of generic comments
+ *
+ * @author Kapralov Sergey
+ */
+public class PsrcFromComments implements PuzzleSource {
+    private final TriggerWord triggerWord;
+    private final List<String> comments;
+
+    /**
+     * Ctor.
+     *
+     * @param triggerWord Trigger word for three-pars algorithm
+     * @param comments comments to parse
+     */
+    public PsrcFromComments(TriggerWord triggerWord, List<String> comments) {
+        this.triggerWord = triggerWord;
+        this.comments = comments;
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param triggerWord Trigger word for three-pars algorithm
+     * @param comments comments to parse
+     */
+    public PsrcFromComments(TriggerWord triggerWord, String... comments) {
+        this(
+            triggerWord,
+            List.of(comments)
+        );
+    }
+
+    @Override
+    public final List<Puzzle> puzzles() {
+        return comments
+            .map(body -> new TxtStandard(
+                triggerWord,
+                body
+            ))
+            .filter(txt -> txt.paragraphs().exists(p -> p.type() == CONTROLLING))
+            .map(txt -> new PzlUsingThreeParsText(txt))
+            .collect(List.collector());
+    }
+}

--- a/puzzler-core/src/test/java/com/github/skapral/puzzler/core/source/PsrcFromCommentsTest.java
+++ b/puzzler-core/src/test/java/com/github/skapral/puzzler/core/source/PsrcFromCommentsTest.java
@@ -1,0 +1,37 @@
+package com.github.skapral.puzzler.core.source;
+
+import com.github.skapral.puzzler.core.puzzle.PzlStatic;
+import com.github.skapral.puzzler.core.text.threepars.TwStatic;
+import com.pragmaticobjects.oo.tests.TestCase;
+import com.pragmaticobjects.oo.tests.junit5.TestsSuite;
+
+class PsrcFromCommentsTest extends TestsSuite {
+    public PsrcFromCommentsTest() {
+        super(
+            new TestCase(
+                "puzzle source produces puzzles from comments",
+                new AssertPuzzleSourceProducesCertainPuzzles(
+                    new PsrcFromComments(
+                        new TwStatic("@puzzlerbot"),
+                        String.join(
+                            "\r\n",
+                            "Some arbitrary comment"
+                        ),
+                        String.join(
+                            "\r\n",
+                            "@puzzlerbot FYI",
+                            "",
+                            "Something wrong happened",
+                            "",
+                            "Description of what is wrong"
+                        )
+                    ),
+                    new PzlStatic(
+                        "Something wrong happened",
+                        "Description of what is wrong"
+                    )
+                )
+            )
+        );
+    }
+}


### PR DESCRIPTION
## Root cause of the issue
`PsrcFromGtihubComments` must be refactored - part which extracts bodies of GitHub comments must be extracted to a separate class for the sake of reusability.

## Description of the changes
`PsrcFromComments` was introduced. `PsrcFromGtihubComments` was rewritten as an inference through `PsrcFromComments`.

## Checklist

- [x] No classes in this PR were explicitly annotated with `@Atom` or `@NotAtom` annotation,
or the reason for such intention is provided in PR description.
