### PR TITLE
#22: Removed puzzle

### DIFF
--- a/puzzler-github/src/main/java/com/github/skapral/puzzler/github/itracker/ItGithubIssues.java
+++ b/puzzler-github/src/main/java/com/github/skapral/puzzler/github/itracker/ItGithubIssues.java
@@ -41,7 +41,6 @@ import java.nio.charset.Charset;
  * Github issue tracker ('issues' tab)
  *
  * @author Kapralov Sergey
- * @todo #20 Improve test coverage for {@link ItGithubIssues}.
  */
 public class ItGithubIssues implements IssueTracker {
     private final GithubAPI api;


### PR DESCRIPTION
Closes #22 

## Root cause of the issue
Puzzle was left unremoved after #85 was closed.

## Description of the changes
Removed the redundant puzzle

## Checklist

- [X] No classes in this PR were explicitly annotated with `@Atom` or `@NotAtom` annotation,
or the reason for such intention is provided in PR description.
