### PR TITLE
#55: Uses IOUtils.toString method with explicit charset. Closes stream with try-with-resource block.

### DIFF
--- a/puzzler-github/src/test/java/com/github/skapral/puzzler/github/operation/OpIgnoringUnprivildgedEventSenderTest.java
+++ b/puzzler-github/src/test/java/com/github/skapral/puzzler/github/operation/OpIgnoringUnprivildgedEventSenderTest.java
@@ -1,5 +1,7 @@
 package com.github.skapral.puzzler.github.operation;
 
+import java.io.InputStream;
+
 import com.github.skapral.puzzler.core.operation.AssertOperationFails;
 import com.github.skapral.puzzler.core.operation.AssertOperationSuccessful;
 import com.github.skapral.puzzler.core.operation.OpFail;
@@ -17,9 +19,10 @@ class OpIgnoringUnprivildgedEventSenderTest extends TestsSuite {
     private static final String OWNER_IS_NOT_SENDER;
 
     static {
-        try {
-            OWNER_IS_SENDER = IOUtils.toString(OpValidatingGithubEventSignature.class.getResource("ownerIsSender"));
-            OWNER_IS_NOT_SENDER = IOUtils.toString(OpValidatingGithubEventSignature.class.getResource("ownerIsNotSender"));
+        try (InputStream ownerIsSenderStream = OpValidatingGithubEventSignature.class.getResource("ownerIsSender").openStream();
+             InputStream ownerIsNotSenderStream = OpValidatingGithubEventSignature.class.getResource("ownerIsNotSender").openStream()) {
+            OWNER_IS_SENDER = IOUtils.toString(ownerIsSenderStream, "UTF-8");
+            OWNER_IS_NOT_SENDER = IOUtils.toString(ownerIsNotSenderStream, "UTF-8");
         } catch(Exception ex) {
             throw new RuntimeException(ex);
         }

--- a/puzzler-github/src/test/java/com/github/skapral/puzzler/github/operation/OpValidatingGithubEventSignatureTest.java
+++ b/puzzler-github/src/test/java/com/github/skapral/puzzler/github/operation/OpValidatingGithubEventSignatureTest.java
@@ -25,6 +25,8 @@
 
 package com.github.skapral.puzzler.github.operation;
 
+import java.io.InputStream;
+
 import com.github.skapral.puzzler.core.config.CpMissingValue;
 import com.github.skapral.puzzler.core.config.CpStatic;
 import com.github.skapral.puzzler.core.operation.AssertOperationFails;
@@ -43,8 +45,8 @@ class OpValidatingGithubEventSignatureTest extends TestsSuite {
     private static final String SIGNED_BODY;
 
     static {
-        try {
-            SIGNED_BODY = IOUtils.toString(OpValidatingGithubEventSignature.class.getResource("signedBody"));
+        try (InputStream signedBodyStream = OpValidatingGithubEventSignature.class.getResource("signedBody").openStream()) {
+            SIGNED_BODY = IOUtils.toString(signedBodyStream, "UTF-8");
         } catch(Exception ex) {
             throw new RuntimeException(ex);
         }


### PR DESCRIPTION
Closes #55 

Based on JavaDoc for IOUtils.toString (https://commons.apache.org/proper/commons-io/javadocs/api-2.6/org/apache/commons/io/IOUtils.html#toString-java.net.URL-)

Also I close streams because IOUtils by default do not close it (please follow class JavaDoc: "Wherever possible, the methods in this class do not flush or close the stream").