### PR TITLE
#91: Information about GITHUB_PUZZLERBOT_USER was added

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -25,13 +25,14 @@ $ GITHUB_AUTH_TOKEN=<token> GITLAB_AUTH_TOKEN=<token> java -jar puzzler-app-*.ja
 
 ### Environment variables
 
-| Name                 | Mandatory?  | Description                                                                                |
-|----------------------|-------------|--------------------------------------------------------------------------------------------|
-| GITHUB_AUTH_TOKEN    | True *      | Valid Github API authentication token, which has at least `repo` permissions.              |
-| GITLAB_AUTH_TOKEN    | True **     | Valid Gitlab personal access token, which has at least `api` permissions.                  |
-| PORT                 | False       | Port number for HTTP endpoints (5000 by default)                                           |
-| GITHUB_HOOK_SECRET   | False       | Github hook expectedToken. If provided, each Github event payload is validated using this expectedToken. |
-| GITLAB_HOOK_SECRET   | False       | Gitlab hook expectedToken. If provided, each Gitlab event payload is validated using this expectedToken. |
+| Name                   | Mandatory?  | Description                                                                                |
+|------------------------|-------------|--------------------------------------------------------------------------------------------|
+| GITHUB_AUTH_TOKEN      | True *      | Valid Github API authentication token, which has at least `repo` permissions.              |
+| GITLAB_AUTH_TOKEN      | True **     | Valid Gitlab personal access token, which has at least `api` permissions.                  |
+| PORT                   | False       | Port number for HTTP endpoints (5000 by default)                                           |
+| GITHUB_HOOK_SECRET     | False       | Github hook expectedToken. If provided, each Github event payload is validated using this expectedToken. |
+| GITLAB_HOOK_SECRET     | False       | Gitlab hook expectedToken. If provided, each Gitlab event payload is validated using this expectedToken. |
+| GITHUB_PUZZLERBOT_USER | False       | Puzzlerbot user's name, for which puzzlerbot scans when searches for puzzles. Default is `puzzlerbot` |
 
 `*` - Mandatory for using the `@puzzlebot`'s `/github` webhook
 


### PR DESCRIPTION
Closes #91 

## Root cause of the issue
GITHUB_PUZZLERBOT_USER, introduced in scope of #89, was left undescribed in DEPLOYMENT guide.

## Description of the changes
Added description of new environment variable in deployment guide

## Checklist
- [X] No classes in this PR were explicitly annotated with `@Atom` or `@NotAtom` annotation,
or the reason for such intention is provided in PR description.
