### PR TITLE
#90: Corrected license headers

### DIFF
--- a/puzzler-core/src/main/java/com/github/skapral/puzzler/core/config/AssertConfigPropertyHasValue.java
+++ b/puzzler-core/src/main/java/com/github/skapral/puzzler/core/config/AssertConfigPropertyHasValue.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) %today.year Kapralov Sergey
+ * Copyright (c) 2018 Kapralov Sergey
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  *
  */
 

--- a/puzzler-core/src/main/java/com/github/skapral/puzzler/core/config/AssertConfigPropertyIsUnitialized.java
+++ b/puzzler-core/src/main/java/com/github/skapral/puzzler/core/config/AssertConfigPropertyIsUnitialized.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) %today.year Kapralov Sergey
+ * Copyright (c) 2018 Kapralov Sergey
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  *
  */
 

--- a/puzzler-core/src/main/java/com/github/skapral/puzzler/core/config/package-info.java
+++ b/puzzler-core/src/main/java/com/github/skapral/puzzler/core/config/package-info.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) %today.year Kapralov Sergey
+ * Copyright (c) 2018 Kapralov Sergey
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  *
  */
 

--- a/puzzler-core/src/main/java/com/github/skapral/puzzler/core/operation/OpFail.java
+++ b/puzzler-core/src/main/java/com/github/skapral/puzzler/core/operation/OpFail.java
@@ -1,3 +1,28 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 Kapralov Sergey
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
 package com.github.skapral.puzzler.core.operation;
 
 import com.github.skapral.puzzler.core.Operation;

--- a/puzzler-core/src/main/java/com/github/skapral/puzzler/core/source/PsrcFromComments.java
+++ b/puzzler-core/src/main/java/com/github/skapral/puzzler/core/source/PsrcFromComments.java
@@ -1,3 +1,28 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 Kapralov Sergey
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
 package com.github.skapral.puzzler.core.source;
 
 import com.github.skapral.puzzler.core.Puzzle;

--- a/puzzler-core/src/main/java/com/github/skapral/puzzler/core/text/threepars/TxtBase.java
+++ b/puzzler-core/src/main/java/com/github/skapral/puzzler/core/text/threepars/TxtBase.java
@@ -1,3 +1,28 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 Kapralov Sergey
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
 package com.github.skapral.puzzler.core.text.threepars;
 
 import io.vavr.collection.List;

--- a/puzzler-core/src/main/java/com/github/skapral/puzzler/core/text/threepars/TxtTrim.java
+++ b/puzzler-core/src/main/java/com/github/skapral/puzzler/core/text/threepars/TxtTrim.java
@@ -1,3 +1,28 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 Kapralov Sergey
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
 package com.github.skapral.puzzler.core.text.threepars;
 
 import io.vavr.collection.List;

--- a/puzzler-core/src/main/java/com/github/skapral/puzzler/mock/AssertAssumingMockServer.java
+++ b/puzzler-core/src/main/java/com/github/skapral/puzzler/mock/AssertAssumingMockServer.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) %today.year Kapralov Sergey
+ * Copyright (c) 2018 Kapralov Sergey
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  *
  */
 

--- a/puzzler-core/src/main/java/com/github/skapral/puzzler/mock/AssertHttpEndpointProducesExpectedResponse.java
+++ b/puzzler-core/src/main/java/com/github/skapral/puzzler/mock/AssertHttpEndpointProducesExpectedResponse.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) %today.year Kapralov Sergey
+ * Copyright (c) 2018 Kapralov Sergey
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  *
  */
 

--- a/puzzler-core/src/main/java/com/github/skapral/puzzler/mock/MockServer.java
+++ b/puzzler-core/src/main/java/com/github/skapral/puzzler/mock/MockServer.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) %today.year Kapralov Sergey
+ * Copyright (c) 2018 Kapralov Sergey
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  *
  */
 

--- a/puzzler-core/src/main/java/com/github/skapral/puzzler/mock/MockSrvImplementation.java
+++ b/puzzler-core/src/main/java/com/github/skapral/puzzler/mock/MockSrvImplementation.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) %today.year Kapralov Sergey
+ * Copyright (c) 2018 Kapralov Sergey
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  *
  */
 

--- a/puzzler-core/src/main/java/com/github/skapral/puzzler/mock/package-info.java
+++ b/puzzler-core/src/main/java/com/github/skapral/puzzler/mock/package-info.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) %today.year Kapralov Sergey
+ * Copyright (c) 2018 Kapralov Sergey
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  *
  */
 

--- a/puzzler-core/src/test/java/com/github/skapral/puzzler/core/config/CpOneOfTest.java
+++ b/puzzler-core/src/test/java/com/github/skapral/puzzler/core/config/CpOneOfTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) %today.year Kapralov Sergey
+ * Copyright (c) 2018 Kapralov Sergey
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  *
  */
 

--- a/puzzler-core/src/test/java/com/github/skapral/puzzler/core/source/PsrcFromCommentsTest.java
+++ b/puzzler-core/src/test/java/com/github/skapral/puzzler/core/source/PsrcFromCommentsTest.java
@@ -1,3 +1,28 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 Kapralov Sergey
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
 package com.github.skapral.puzzler.core.source;
 
 import com.github.skapral.puzzler.core.puzzle.PzlStatic;

--- a/puzzler-core/src/test/java/com/github/skapral/puzzler/mock/MockSrvImplementationTest.java
+++ b/puzzler-core/src/test/java/com/github/skapral/puzzler/mock/MockSrvImplementationTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) %today.year Kapralov Sergey
+ * Copyright (c) 2018 Kapralov Sergey
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  *
  */
 

--- a/puzzler-core/src/test/java/com/github/skapral/puzzler/mock/package-info.java
+++ b/puzzler-core/src/test/java/com/github/skapral/puzzler/mock/package-info.java
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  *
- *
  */
 
 package com.github.skapral.puzzler.mock;

--- a/puzzler-github/src/main/java/com/github/skapral/puzzler/github/config/Cp_GITHUB_AUTH_TOKEN.java
+++ b/puzzler-github/src/main/java/com/github/skapral/puzzler/github/config/Cp_GITHUB_AUTH_TOKEN.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) %today.year Kapralov Sergey
+ * Copyright (c) 2018 Kapralov Sergey
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  *
  */
 

--- a/puzzler-github/src/main/java/com/github/skapral/puzzler/github/config/Cp_GITHUB_HOOK_SECRET.java
+++ b/puzzler-github/src/main/java/com/github/skapral/puzzler/github/config/Cp_GITHUB_HOOK_SECRET.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) %today.year Kapralov Sergey
+ * Copyright (c) 2018 Kapralov Sergey
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  *
  */
 

--- a/puzzler-github/src/main/java/com/github/skapral/puzzler/github/config/Cp_GITHUB_PUZZLERBOT_USER.java
+++ b/puzzler-github/src/main/java/com/github/skapral/puzzler/github/config/Cp_GITHUB_PUZZLERBOT_USER.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) %today.year Kapralov Sergey
+ * Copyright (c) 2018 Kapralov Sergey
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  *
  */
 

--- a/puzzler-github/src/main/java/com/github/skapral/puzzler/github/config/package-info.java
+++ b/puzzler-github/src/main/java/com/github/skapral/puzzler/github/config/package-info.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) %today.year Kapralov Sergey
+ * Copyright (c) 2018 Kapralov Sergey
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  *
  */
 

--- a/puzzler-github/src/main/java/com/github/skapral/puzzler/github/operation/OpIgnoringUnprivildgedEventSender.java
+++ b/puzzler-github/src/main/java/com/github/skapral/puzzler/github/operation/OpIgnoringUnprivildgedEventSender.java
@@ -1,3 +1,28 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 Kapralov Sergey
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
 package com.github.skapral.puzzler.github.operation;
 
 import com.github.skapral.puzzler.core.Operation;

--- a/puzzler-github/src/test/java/com/github/skapral/puzzler/github/operation/OpIgnoringUnprivildgedEventSenderTest.java
+++ b/puzzler-github/src/test/java/com/github/skapral/puzzler/github/operation/OpIgnoringUnprivildgedEventSenderTest.java
@@ -1,3 +1,28 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 Kapralov Sergey
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
 package com.github.skapral.puzzler.github.operation;
 
 import java.io.InputStream;

--- a/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/config/Cp_GITLAB_AUTH_TOKEN.java
+++ b/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/config/Cp_GITLAB_AUTH_TOKEN.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) %today.year Kapralov Sergey
+ * Copyright (c) 2018 Kapralov Sergey
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  *
  */
 

--- a/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/config/Cp_GITLAB_HOOK_SECRET.java
+++ b/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/config/Cp_GITLAB_HOOK_SECRET.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) %today.year Kapralov Sergey
+ * Copyright (c) 2018 Kapralov Sergey
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  *
  */
 

--- a/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/config/package-info.java
+++ b/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/config/package-info.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) %today.year Kapralov Sergey
+ * Copyright (c) 2018 Kapralov Sergey
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  *
  */
 

--- a/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/itracker/ItGitlabIssues.java
+++ b/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/itracker/ItGitlabIssues.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) %today.year Kapralov Sergey
+ * Copyright (c) 2018 Kapralov Sergey
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  *
  */
 

--- a/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/itracker/package-info.java
+++ b/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/itracker/package-info.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) %today.year Kapralov Sergey
+ * Copyright (c) 2018 Kapralov Sergey
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  *
  */
 

--- a/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/location/GitlabAPI.java
+++ b/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/location/GitlabAPI.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) %today.year Kapralov Sergey
+ * Copyright (c) 2018 Kapralov Sergey
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  *
  */
 

--- a/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/location/GlapiProduction.java
+++ b/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/location/GlapiProduction.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) %today.year Kapralov Sergey
+ * Copyright (c) 2018 Kapralov Sergey
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  *
  */
 

--- a/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/location/GlapiStatic.java
+++ b/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/location/GlapiStatic.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) %today.year Kapralov Sergey
+ * Copyright (c) 2018 Kapralov Sergey
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  *
  */
 

--- a/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/location/package-info.java
+++ b/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/location/package-info.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) %today.year Kapralov Sergey
+ * Copyright (c) 2018 Kapralov Sergey
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  *
  */
 

--- a/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/operation/OpValidatingGitlabEventToken.java
+++ b/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/operation/OpValidatingGitlabEventToken.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) %today.year Kapralov Sergey
+ * Copyright (c) 2018 Kapralov Sergey
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  *
  */
 

--- a/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/operation/package-info.java
+++ b/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/operation/package-info.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) %today.year Kapralov Sergey
+ * Copyright (c) 2018 Kapralov Sergey
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  *
  */
 

--- a/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/project/GitlabProject.java
+++ b/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/project/GitlabProject.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) %today.year Kapralov Sergey
+ * Copyright (c) 2018 Kapralov Sergey
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  *
  */
 

--- a/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/project/GprjFromGitlabEvent.java
+++ b/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/project/GprjFromGitlabEvent.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) %today.year Kapralov Sergey
+ * Copyright (c) 2018 Kapralov Sergey
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  *
  */
 

--- a/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/project/package-info.java
+++ b/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/project/package-info.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) %today.year Kapralov Sergey
+ * Copyright (c) 2018 Kapralov Sergey
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  *
  */
 

--- a/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/source/PsrcFromGitlabEvent.java
+++ b/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/source/PsrcFromGitlabEvent.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) %today.year Kapralov Sergey
+ * Copyright (c) 2018 Kapralov Sergey
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  *
  */
 

--- a/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/source/PsrcFromGitlabNotes.java
+++ b/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/source/PsrcFromGitlabNotes.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) %today.year Kapralov Sergey
+ * Copyright (c) 2018 Kapralov Sergey
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  *
  */
 

--- a/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/source/package-info.java
+++ b/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/source/package-info.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) %today.year Kapralov Sergey
+ * Copyright (c) 2018 Kapralov Sergey
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  *
  */
 

--- a/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/text/threepars/TwPuzzlerbotUser.java
+++ b/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/text/threepars/TwPuzzlerbotUser.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) %today.year Kapralov Sergey
+ * Copyright (c) 2018 Kapralov Sergey
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  *
  */
 

--- a/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/text/threepars/package-info.java
+++ b/puzzler-gitlab/src/main/java/com/github/skapral/puzzler/gitlab/text/threepars/package-info.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) %today.year Kapralov Sergey
+ * Copyright (c) 2018 Kapralov Sergey
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  *
  */
 

--- a/puzzler-gitlab/src/test/java/com/github/skapral/puzzler/gitlab/operation/OpValidatingGitlabEventTokenTest.java
+++ b/puzzler-gitlab/src/test/java/com/github/skapral/puzzler/gitlab/operation/OpValidatingGitlabEventTokenTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) %today.year Kapralov Sergey
+ * Copyright (c) 2018 Kapralov Sergey
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  *
  */
 

--- a/puzzler-gitlab/src/test/java/com/github/skapral/puzzler/gitlab/operation/package-info.java
+++ b/puzzler-gitlab/src/test/java/com/github/skapral/puzzler/gitlab/operation/package-info.java
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  *
- *
  */
 
 package com.github.skapral.puzzler.gitlab.operation;

--- a/puzzler-gitlab/src/test/java/com/github/skapral/puzzler/gitlab/source/PsrcFromGitlabEventTest.java
+++ b/puzzler-gitlab/src/test/java/com/github/skapral/puzzler/gitlab/source/PsrcFromGitlabEventTest.java
@@ -1,7 +1,7 @@
 /*
  * MIT License
  *
- * Copyright (c) %today.year Kapralov Sergey
+ * Copyright (c) 2018 Kapralov Sergey
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  *
  */
 

--- a/puzzler-gitlab/src/test/java/com/github/skapral/puzzler/gitlab/source/package-info.java
+++ b/puzzler-gitlab/src/test/java/com/github/skapral/puzzler/gitlab/source/package-info.java
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  *
- *
  */
 
 package com.github.skapral.puzzler.gitlab.source;


### PR DESCRIPTION
Closes #90 

## Root cause of the issue
License headers were corrupted in several java modules

## Description of the changes
Corrected license headers.

## Checklist

- [ ] No classes in this PR were explicitly annotated with `@Atom` or `@NotAtom` annotation,
or the reason for such intention is provided in PR description.
